### PR TITLE
v2.0.1 to master (fixes deleted 2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/prometheus_alertmanager-role/tree/develop)
 
-### Fixed
-- *Fix global template* @jnogol
-
-## [2.0.0](https://github.com/idealista/prometheus_alertmanager-role/tree/2.0.0) (2018-06-14)
-[Full Changelog](https://github.com/idealista/prometheus_alertmanager-role/compare/1.0.1...2.0.0)
+## [2.0.1](https://github.com/idealista/prometheus_alertmanager-role/tree/2.0.1) (2018-06-18)
+[Full Changelog](https://github.com/idealista/prometheus_alertmanager-role/compare/1.0.1...2.0.1)
 
 ### Added
 - *Add .github folder* @jnogol
@@ -22,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ### Fixed
 - *[#4](https://github.com/idealista/prometheus_alertmanager-role-role/issues/4) Double dash for newest Alertmanager versions* @jnogol
+- *Fix global template* @jnogol
 
 ## [1.0.1](https://github.com/idealista/prometheus_alertmanager-role/tree/1.0.1) (2017-03-02)
 [Full Changelog](https://github.com/idealista/prometheus_alertmanager-role/compare/1.0.0...1.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *Extract download path to a variable* @jnogol
 
 ### Fixed
-- *[#4](https://github.com/idealista/prometheus_alertmanager-role-role/issues/4) Double hyphen for newest Alertmanager versions* @jnogol
+- *[#4](https://github.com/idealista/prometheus_alertmanager-role-role/issues/4) Double dash for newest Alertmanager versions* @jnogol
 
 ## [1.0.1](https://github.com/idealista/prometheus_alertmanager-role/tree/1.0.1) (2017-03-02)
 [Full Changelog](https://github.com/idealista/prometheus_alertmanager-role/compare/1.0.0...1.0.1)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This ansible role installs an Alert Manager server in a debian environment. The 
 
 ## Getting Started
 
-These instructions will get you a copy of the role for your ansible playbook. Once launched, it will install an [Alert Manager](https://prometheus.io/docs/alerting/alertmanager/) server in a Debian system.
+These instructions will get you a copy of the role for your ansible playbook. Once launched, it will install an [Alert Manager](https://prometheus.io/docs/alerting/alertmanager/) server in a Debian system. The role is only compatible with Alert Manager versions greater than 0.13.0.
 
 ### Prerequisities
 


### PR DESCRIPTION
## [2.0.1](https://github.com/idealista/prometheus_alertmanager-role/tree/2.0.1) (2018-06-18)
[Full Changelog](https://github.com/idealista/prometheus_alertmanager-role/compare/1.0.1...2.0.1)

### Added
- *Add .github folder* @jnogol
- *[#5](https://github.com/idealista/prometheus_alertmanager-role-role/issues/5) Add CircleCI* @jnogol

### Changed
- *Update README.md* @jnogol
- *Update Alertmanager default version* @jnogol
- *Use alertmanager group in Molecule tests* @jnogol
- *Extract download path to a variable* @jnogol

### Fixed
- *[#4](https://github.com/idealista/prometheus_alertmanager-role-role/issues/4) Double dash for newest Alertmanager versions* @jnogol
- *Fix global template* @jnogol